### PR TITLE
Batch Dependabot: checkout + setup-dotnet action bumps

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Lint and Test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Extract Release Info
         if: github.event_name == 'release'
@@ -90,7 +90,7 @@ jobs:
     environment:
       name: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'release') && 'production' || 'staging' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: true
           lfs: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -44,7 +44,7 @@ jobs:
         done
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: '10.0.x'
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,7 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Extract Release Info
       if: github.event_name == 'release'
@@ -90,7 +90,7 @@ jobs:
       name: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'release') && 'production' || 'staging' }}
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Download Artifact
       uses: actions/download-artifact@v4

--- a/.github/workflows/selfhost-docker.yml
+++ b/.github/workflows/selfhost-docker.yml
@@ -22,7 +22,7 @@ jobs:
   docker-and-bundle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Resolve release info
         shell: bash


### PR DESCRIPTION
Follow-up batch of the newly-arrived safe GitHub Actions bumps.

- `actions/checkout` 4 → 7 (#66) — across all workflows
- `actions/setup-dotnet` 4 → 6 (#67) — dotnet.yml

Merged cleanly, no conflicts. Angular/primeng v22 majors still excluded (handled separately). #48/#50 are already in main and will auto-close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)